### PR TITLE
Fix auto_prefix does not recognize '\'

### DIFF
--- a/autoload/partedit.vim
+++ b/autoload/partedit.vim
@@ -77,7 +77,7 @@ function! partedit#start(startline, endline, ...)
       if line ==# ''
         continue
       endif
-      let pat = substitute(line, '.', '[\0]', 'g')
+      let pat = escape(substitute(line, '.', '[\0]', 'g'),'\')
       let prefix = matchstr(prefix, '^\%[' . pat . ']')
       if prefix ==# ''
         break


### PR DESCRIPTION

```
\{
\    'hoge': 'fuga'
\}
```

上のようなテキストを選択して  
`:'<,'>Partedit`  
をした時に、`\`が prefix として認識されなかったので修正しました。  
  
初めての pull request なので、何かまずい点などがあればご指摘いただけるとありがたいです。