### PR TITLE
add option: `prefix_pattern`

### DIFF
--- a/autoload/partedit.vim
+++ b/autoload/partedit.vim
@@ -175,8 +175,19 @@ function! s:trim_contents(contents, prefix, auto_prefix, prefix_pattern,)
 
   if a:prefix_pattern !=# ''
 
+    let allow_empty_line = ('' =~# '^' .. a:prefix_pattern)
+
     let len_prefix = -1
     for line in contents
+      if line ==# ''
+        if allow_empty_line
+          continue
+        else
+          let prefix = ''
+          let len_prefix = 0
+          break
+        endif
+      endif
       if len_prefix != -1
         let line = line[:len_prefix]
       endif

--- a/autoload/partedit.vim
+++ b/autoload/partedit.vim
@@ -178,20 +178,20 @@ function! s:trim_contents(contents, prefix, auto_prefix, prefix_pattern,)
     let len_prefix = -1
 
     for line in contents
-      if line =~# '^' .. a:prefix_pattern .. '\v$'
+      if line =~# '^' . a:prefix_pattern . '\v$'
         continue
       endif
       if len_prefix > 0
-        let line = line[:len_prefix - 1]
+        let line = line[: len_prefix - 1]
       endif
-      let prefix_provisional = matchstr(line, '^' .. a:prefix_pattern)
+      let prefix_provisional = matchstr(line, '^' . a:prefix_pattern)
       let len_prefix = strlen(prefix_provisional)
       if len_prefix == 0
         break
       endif
     endfor
 
-    call map(contents, 'v:val[len_prefix:]')
+    call map(contents, 'v:val[len_prefix :]')
     let prefix = prefix_provisional
 
   else

--- a/autoload/partedit.vim
+++ b/autoload/partedit.vim
@@ -170,12 +170,13 @@ function! s:get_option(name, base, default)
 endfunction
 
 function! s:trim_contents(contents, prefix, auto_prefix, prefix_pattern,)
-  let contents = a:contents
+  let contents = copy(a:contents)
   let prefix = a:prefix
 
   if a:prefix_pattern !=# ''
-
+    let prefix_provisional = ''
     let len_prefix = -1
+
     for line in contents
       if line =~# '^' .. a:prefix_pattern .. '\v$'
         continue

--- a/autoload/partedit.vim
+++ b/autoload/partedit.vim
@@ -48,47 +48,12 @@ function! partedit#start(startline, endline, ...)
   let options = a:0 ? a:1 : {}
   let original_bufnr = bufnr('%')
   let contents = getline(a:startline, a:endline)
-  let original_contents = contents
+  let original_contents = copy(contents)
 
   let prefix = s:get_option('prefix', options, '')
-  if prefix !=# ''
-    let sprefix = substitute(prefix, '\s\+$', '', '')
-    let len = len(sprefix)
-    let pos = len - 1
-    let all_prefix_exists = 1
-    for line in contents
-      if line[: pos] !=# sprefix
-        let all_prefix_exists = 0
-        break
-      endif
-    endfor
-    if all_prefix_exists
-      let original_contents = copy(contents)
-      let pat = '^' . substitute(prefix, '\s\+$', '\\%(\0\\|$\\)', '')
-      call map(contents, 'substitute(v:val, pat, "", "")')
-    else
-      let prefix = ''
-    endif
-  endif
   let auto_prefix = s:get_option('auto_prefix', options, 1)
-  if prefix ==# '' && auto_prefix && 2 <= len(contents)
-    let prefix = contents[0]
-    for line in contents[1 :]
-      if line ==# ''
-        continue
-      endif
-      let pat = escape(substitute(line, '.', '[\0]', 'g'),'\')
-      let prefix = matchstr(prefix, '^\%[' . pat . ']')
-      if prefix ==# ''
-        break
-      endif
-    endfor
-    if prefix !=# ''
-      let original_contents = copy(contents)
-      let len = len(prefix)
-      call map(contents, 'v:val[len :]')
-    endif
-  endif
+  let prefix_pattern = s:get_option('prefix_pattern', options, '')
+  let [contents, prefix] = s:trim_contents(contents, prefix, auto_prefix, prefix_pattern)
 
   let filetype = s:get_option('filetype', options, &l:filetype)
   let [fenc, ff] = [&l:fileencoding, &l:fileformat]
@@ -202,6 +167,70 @@ function! s:get_option(name, base, default)
     return g:partedit#{a:name}
   endif
   return a:default
+endfunction
+
+function! s:trim_contents(contents, prefix, auto_prefix, prefix_pattern,)
+  let contents = a:contents
+  let prefix = a:prefix
+
+  if a:prefix_pattern !=# ''
+
+    let len_prefix = -1
+    for line in contents
+      if len_prefix != -1
+        let line = line[:len_prefix]
+      endif
+      let prefix_provisional = matchstr(line, '^' .. a:prefix_pattern)
+      let len_prefix = strlen(prefix_provisional)
+      if len_prefix == 0
+        break
+      endif
+    endfor
+
+    call map(contents, 'v:val[len_prefix:]')
+    let prefix = prefix_provisional
+
+  else
+
+    if prefix !=# ''
+      let sprefix = substitute(prefix, '\s\+$', '', '')
+      let len = len(sprefix)
+      let pos = len - 1
+      let all_prefix_exists = 1
+      for line in contents
+        if line[: pos] !=# sprefix
+          let all_prefix_exists = 0
+          break
+        endif
+      endfor
+      if all_prefix_exists
+        let pat = '^' . substitute(prefix, '\s\+$', '\\%(\0\\|$\\)', '')
+        call map(contents, 'substitute(v:val, pat, "", "")')
+      else
+        let prefix = ''
+      endif
+    endif
+    if prefix ==# '' && a:auto_prefix && 2 <= len(contents)
+      let prefix = contents[0]
+      for line in contents[1 :]
+        if line ==# ''
+          continue
+        endif
+        let pat = escape(substitute(line, '.', '[\0]', 'g'),'\')
+        let prefix = matchstr(prefix, '^\%[' . pat . ']')
+        if prefix ==# ''
+          break
+        endif
+      endfor
+      if prefix !=# ''
+        let len = len(prefix)
+        call map(contents, 'v:val[len :]')
+      endif
+    endif
+
+  endif
+
+  return [contents, prefix]
 endfunction
 
 

--- a/autoload/partedit.vim
+++ b/autoload/partedit.vim
@@ -177,7 +177,7 @@ function! s:trim_contents(contents, prefix, auto_prefix, prefix_pattern,)
 
     let len_prefix = -1
     for line in contents
-      if line =~# '^' .. a:prefix_pattern .. '$'
+      if line =~# '^' .. a:prefix_pattern .. '\v$'
         continue
       endif
       if len_prefix > 0

--- a/autoload/partedit.vim
+++ b/autoload/partedit.vim
@@ -175,18 +175,10 @@ function! s:trim_contents(contents, prefix, auto_prefix, prefix_pattern,)
 
   if a:prefix_pattern !=# ''
 
-    let allow_empty_line = ('' =~# '^' .. a:prefix_pattern)
-
     let len_prefix = -1
     for line in contents
-      if line ==# ''
-        if allow_empty_line
-          continue
-        else
-          let prefix = ''
-          let len_prefix = 0
-          break
-        endif
+      if line =~# '^' .. a:prefix_pattern .. '$'
+        continue
       endif
       if len_prefix > 0
         let line = line[:len_prefix - 1]

--- a/autoload/partedit.vim
+++ b/autoload/partedit.vim
@@ -47,13 +47,12 @@ function! partedit#start(startline, endline, ...)
   endif
   let options = a:0 ? a:1 : {}
   let original_bufnr = bufnr('%')
-  let contents = getline(a:startline, a:endline)
-  let original_contents = copy(contents)
+  let original_contents = getline(a:startline, a:endline)
 
   let prefix = s:get_option('prefix', options, '')
   let auto_prefix = s:get_option('auto_prefix', options, 1)
   let prefix_pattern = s:get_option('prefix_pattern', options, '')
-  let [contents, prefix] = s:trim_contents(contents, prefix, auto_prefix, prefix_pattern)
+  let [contents, prefix] = s:trim_contents(original_contents, prefix, auto_prefix, prefix_pattern)
 
   let filetype = s:get_option('filetype', options, &l:filetype)
   let [fenc, ff] = [&l:fileencoding, &l:fileformat]

--- a/autoload/partedit.vim
+++ b/autoload/partedit.vim
@@ -188,8 +188,8 @@ function! s:trim_contents(contents, prefix, auto_prefix, prefix_pattern,)
           break
         endif
       endif
-      if len_prefix != -1
-        let line = line[:len_prefix]
+      if len_prefix > 0
+        let line = line[:len_prefix - 1]
       endif
       let prefix_provisional = matchstr(line, '^' .. a:prefix_pattern)
       let len_prefix = strlen(prefix_provisional)

--- a/doc/partedit.txt
+++ b/doc/partedit.txt
@@ -111,23 +111,15 @@ b:partedit_prefix				*b:partedit_prefix*
 	> All texts are restored with "> " prefix,
 	> but blank of the end of empty line is removed.
 
-g:partedit#filetype				*g:partedit#filetype*
-b:partedit_filetype				*b:partedit_filetype*
-	If this variable exists, 'filetype' of newly opened partedit buffer
-	becomes this value.
-
-g:partedit#auto_prefix				*g:partedit#auto_prefix*
-b:partedit_auto_prefix				*b:partedit_auto_prefix*
-	If this is true, and both |b:partedit_prefix| and
-	|b:partedit_prefix_pattern| are empty, the common prefix of range is
-	treated as prefix.  The default value is true.
-
 g:partedit#prefix_pattern			*g:partedit#prefix_pattern*
 b:partedit_prefix_pattern			*b:partedit_prefix_pattern*
 	Similar to |b:partedit_prefix|, but this option can be specified by a
 	regex.  If this value is not empty, the common prefix of range that
 	matches the specified regex is treated as prefix.  With this option
 	set, |b:partedit_prefix| and |b:partedit_auto_prefix| are ignored.
+	The longest common string satisfying the given regex is treated as a
+	prefix, and it is restored to the original buffer after editing the
+	partedit buffer.
 >
 	let b:partedit_prefix = '\v\s*//[/!]?\s*'
 
@@ -141,6 +133,24 @@ b:partedit_prefix_pattern			*b:partedit_prefix_pattern*
 	
 	Upper line has prefix "//", not "// ". But this is OK.
 
+		| edit
+		v
+	=== partedit buffer ===
+	This is a sample text.
+	
+	Upper line has prefix "//", not "// ". But this is OK.
+	
+	All texts are restored with "// " prefix,
+	but blank of the end of empty line is removed.
+
+	=== original buffer ===
+	// This is a sample text.
+	//
+	// Upper line has prefix "//", not "// ". But this is OK.
+	//
+	// All texts are restored with "// " prefix,
+	// but blank of the end of empty line is removed.
+
 	=== original buffer ===
 	//! This is a sample documentation text.
 	//!
@@ -150,6 +160,36 @@ b:partedit_prefix_pattern			*b:partedit_prefix_pattern*
 	This is a sample documentation text.
 	
 	Upper line has prefix "//!", not "//! ". But this is OK.
+
+		| edit
+		v
+	=== partedit buffer ===
+	This is a sample documentation text.
+	
+	Upper line has prefix "//!", not "//! ". But this is OK.
+	
+	All texts are restored with "//! " prefix,
+	but blank of the end of empty line is removed.
+
+	=== original buffer ===
+	//! This is a sample documentation text.
+	//!
+	//! Upper line has prefix "//!", not "//! ". But this is OK.
+	//!
+	//! All texts are restored with "//! " prefix,
+	//! but blank of the end of empty line is removed.
+
+
+g:partedit#filetype				*g:partedit#filetype*
+b:partedit_filetype				*b:partedit_filetype*
+	If this variable exists, 'filetype' of newly opened partedit buffer
+	becomes this value.
+
+g:partedit#auto_prefix				*g:partedit#auto_prefix*
+b:partedit_auto_prefix				*b:partedit_auto_prefix*
+	If this is true, and both |b:partedit_prefix| and
+	|b:partedit_prefix_pattern| are empty, the common prefix of range is
+	treated as prefix.  The default value is true.
 
 
 

--- a/doc/partedit.txt
+++ b/doc/partedit.txt
@@ -118,8 +118,38 @@ b:partedit_filetype				*b:partedit_filetype*
 
 g:partedit#auto_prefix				*g:partedit#auto_prefix*
 b:partedit_auto_prefix				*b:partedit_auto_prefix*
-	If this is true and |b:partedit_prefix| is empty, the common prefix of
-	range is treated as prefix.  The default value is true.
+	If this is true, and both |b:partedit_prefix| and
+	|b:partedit_prefix_pattern| are empty, the common prefix of range is
+	treated as prefix.  The default value is true.
+
+g:partedit#prefix_pattern			*g:partedit#prefix_pattern*
+b:partedit_prefix_pattern			*b:partedit_prefix_pattern*
+	Similar to |b:partedit_prefix|, but this option can be specified by a
+	regex.  If this value is not empty, the common prefix of range that
+	matches the specified regex is treated as prefix.  With this option
+	set, |b:partedit_prefix| and |b:partedit_auto_prefix| are ignored.
+>
+	let b:partedit_prefix = '\v\s*//[/!]?\s*'
+
+	=== original buffer ===
+	// This is a sample comment.
+	//
+	// Upper line has prefix "//", not "// ". But this is OK.
+
+	=== partedit buffer ===
+	This is a sample comment.
+	
+	Upper line has prefix "//", not "// ". But this is OK.
+
+	=== original buffer ===
+	//! This is a sample documentation text.
+	//!
+	//! Upper line has prefix "//!", not "//! ". But this is OK.
+
+	=== partedit buffer ===
+	This is a sample documentation text.
+	
+	Upper line has prefix "//!", not "//! ". But this is OK.
 
 
 


### PR DESCRIPTION
`g:partedit#prefix_pattern` 及び `b:partedit_prefix_pattern` を用いて、プレフィックスを正規表現で指定できるようにしました。
Rust のコメント記法のように、prefix が複数種類になりうる場合を主な用途として想定しています。

またその実装の際、prefix を検出して行の内容をトリムする処理を別の関数として切り出しました。