### PR TITLE
feat: winrestview / winsaveview instead of curpos

### DIFF
--- a/autoload/partedit.vim
+++ b/autoload/partedit.vim
@@ -93,7 +93,8 @@ endfunction
 
 function! s:apply()
   let [start, end] = b:partedit__lines
-  let curpos = exists('*getcurpos') ? getcurpos() : getpos('.')
+  let haswinview = exists('*winsaveview') && exists('*winrestview')
+  let curpos = haswinview ? winsaveview() : exists('*getcurpos') ? getcurpos() : getpos('.')
 
   if !v:cmdbang &&
   \    b:partedit__contents != getbufline(b:partedit__bufnr, start, end)
@@ -137,7 +138,11 @@ function! s:apply()
   let b:partedit__contents = contents
   let b:partedit__lines = [start, start + len(contents) - 1]
   setlocal nomodified
-  call setpos('.', curpos)
+  if haswinview
+    call winrestview(curpos)
+  else
+    call setpos('.', curpos)
+  endif
 endfunction
 
 function! s:search_partial(all, part, base)


### PR DESCRIPTION
Partedit バッファの書き込み時に、カーソルがウィンドウの上下中央にくる挙動があったので修正しました。
